### PR TITLE
Fixes imports for api lvl 34

### DIFF
--- a/src/android/android-play-core.gradle
+++ b/src/android/android-play-core.gradle
@@ -1,3 +1,8 @@
 dependencies {
-  implementation 'com.google.android.play:core:1.10.0'
+    // This dependency is downloaded from the Google’s Maven repository.
+    // Make sure you also include that repository in your project's build.gradle file.
+    implementation("com.google.android.play:app-update:2.1.0")
+
+    // For Kotlin users, also import the Kotlin extensions library for Play In-App Update:
+    implementation("com.google.android.play:app-update-ktx:2.1.0")
 }

--- a/src/android/inappupdate.java
+++ b/src/android/inappupdate.java
@@ -16,7 +16,7 @@ import com.google.android.play.core.appupdate.AppUpdateManager;
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory;
 import com.google.android.play.core.install.model.AppUpdateType;
 import com.google.android.play.core.install.model.UpdateAvailability;
-import com.google.android.play.core.tasks.Task;
+import com.google.android.gms.tasks.Task;
 
 
 


### PR DESCRIPTION
This fixes the plugin so its compatible with API Level 34, which is required by the Play Store from the end of August 2024

Its a simple import change, and its described here https://developer.android.com/guide/playcore#kts